### PR TITLE
Initial Spike

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+npm-debug.log

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+resque: npm start

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Hound JSCS
+
+[JSCS] is a code style linter for programmatically enforcing your style guide.
+
+`hound-jscs` is a Node service that polls `JavaScriptReviewJob`s from the
+`java_script_review` queue, lints code with `JSCS`, then pushes the results to
+the `high` queue, as `CompletedFileReviewJob`s.
+
+[JSCS]: http://jscs.info/

--- a/index.js
+++ b/index.js
@@ -1,0 +1,71 @@
+var Redis = require("redis");
+var Resque = require("node-resque");
+var Checker = require("jscs");
+
+function parseConfig(config) {
+  if (!config) {
+    config = "{}";
+  }
+
+  try {
+    return JSON.parse(config);
+  } catch (exception) {
+    console.log("Invalid JSCS configuration:");
+    console.log(config);
+    console.log(exception);
+
+    return {};
+  }
+}
+
+var connection = {
+  redis: Redis.createClient(process.env.REDIS_URL || "redis://localhost:6379"),
+}
+
+var outbound = new Resque.queue({
+  connection: connection,
+  queues: ["high"],
+});
+
+var worker = new Resque.worker({
+  connection: connection,
+  queues: ["jscs_review"],
+}, {
+  "JscsReviewJob": function(payload) {
+    var checker = new Checker();
+    checker.registerDefaultRules();
+    checker.configure(parseConfig(payload.config));
+
+    var results = checker.checkString(payload.content);
+    var violations = results.getErrorList().map(function(error) {
+      return { line: error.line, message: error.message };
+    });
+
+    outbound.connect(function() {
+      outbound.enqueue("high", "CompletedFileReviewJob", {
+        violations: violations,
+        filename: payload.filename,
+        commit_sha: payload.commit_sha,
+        pull_request_number: payload.pull_request_number,
+        patch: payload.patch,
+      });
+    });
+  }
+});
+
+worker.connect(function() {
+  worker.workerCleanup();
+  worker.start();
+});
+
+// var inbound = new Resque.queue({
+//   connection: connection,
+//   queues: ["jscs_review"],
+// });
+//
+// inbound.connect(function() {
+//   inbound.enqueue("jscs_review", "JscsReviewJob", {
+//     content: "// TODO",
+//     config: '{ "disallowKeywordsInComments": true }',
+//   });
+// });

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "JSCS Linter for Hound",
   "main": "index.js",
   "scripts": {
+    "start": "node index.js",
     "test": "qunit -c index.js -t tests/**/*-test.js"
   },
   "repository": {
@@ -21,5 +22,10 @@
   "bugs": {
     "url": "https://github.com/thoughtbot/hound-jscs/issues"
   },
-  "homepage": "https://github.com/thoughtbot/hound-jscs#readme"
+  "homepage": "https://github.com/thoughtbot/hound-jscs#readme",
+  "dependencies": {
+    "jscs": "^2.2.1",
+    "node-resque": "^1.0.2",
+    "redis": "^2.1.0"
+  }
 }


### PR DESCRIPTION

https://trello.com/c/M6hL2wKC

This commit adds an initial implementation that was tested by hand.

Once we get a better sense of how Linters are expected to behave, we can
throw away the spike and test drive the new implementation.

To test locally:

```bash
$ cd node_modules/node-resque/resque-web
$ bundle
$ bundle exec rackup
$ open http://localhost:9292
```

Then, kill `foreman`, uncomment the block at the bottom of `index.js`,
and `foreman start`. Monitor the Resque queue for a
`"JavaScriptReviewJob"` in the `"java_script_review"` queue, as well as
an outgoing `"CompletedFileReviewJob"` in the `"high"` queue.